### PR TITLE
seperate service logic from controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "init": "yarn prisma generate"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.0",
     "@types/cookie-parser": "^1.4.3",
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.17",
@@ -29,6 +30,7 @@
   "dependencies": {
     "@prisma/client": "^5.0.0",
     "axios": "^1.4.0",
+    "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
     "ejs": "^3.1.9",

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,3 @@
+import * as userSerivce from './user.service';
+
+export { userSerivce };

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,8 +1,48 @@
 import { Prisma } from '@prisma/client';
 import prismaClient from '../database';
+import { wwsError } from '../utils/wwsError';
+import HttpStatusCode from 'http-status-codes';
+import bcrypt from 'bcrypt';
 
-export const createUser = async (data: Prisma.UserCreateInput) => {
-  return;
+interface UserCreateInput {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export const createUser = async (data: UserCreateInput) => {
+  const userAlreadyExist = await getUser({
+    local: {
+      email: data.email,
+    },
+  });
+
+  if (userAlreadyExist) {
+    throw new wwsError(
+      HttpStatusCode.CONFLICT,
+      'account already registered with email'
+    );
+  }
+
+  const salt = await bcrypt.genSalt(10);
+
+  const encrypted_password = await bcrypt.hash(data.password, salt);
+
+  const user = await prismaClient.user.create({
+    data: {
+      username: data.username,
+      pfp: '',
+      local: {
+        create: {
+          encrypted_password,
+          email: data.email,
+          email_verified: false,
+        },
+      },
+    },
+  });
+
+  return user;
 };
 
 export const updateUser = async (data: Prisma.UserUpdateInput) => {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,21 +1,21 @@
 import { Prisma } from '@prisma/client';
 import prismaClient from '../database';
 
-export const createUser = async (body: Prisma.UserCreateInput) => {
+export const createUser = async (data: Prisma.UserCreateInput) => {
   return;
 };
 
-export const updateUser = async (body: Prisma.UserUpdateInput) => {
+export const updateUser = async (data: Prisma.UserUpdateInput) => {
   return;
 };
 
-export const deleteUser = async (body: Prisma.UserSelect) => {
+export const deleteUser = async (data: Prisma.UserSelect) => {
   return;
 };
 
-export const getUser = async (body: Prisma.UserWhereInput) => {
+export const getUser = async (data: Prisma.UserWhereInput) => {
   const user = await prismaClient.user.findFirst({
-    where: body,
+    where: data,
   });
 
   return user;

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -6,11 +6,23 @@ import bcrypt from 'bcrypt';
 
 interface UserCreateInput {
   username: string;
+}
+
+interface LocalUserCreateInput extends UserCreateInput {
   email: string;
   password: string;
 }
 
-export const createUser = async (data: UserCreateInput) => {
+interface OauthUserCreateInput extends UserCreateInput {
+  pfp: string;
+
+  provider: string;
+  id: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+export const createLocalUser = async (data: LocalUserCreateInput) => {
   const userAlreadyExist = await getUser({
     local: {
       email: data.email,
@@ -41,6 +53,33 @@ export const createUser = async (data: UserCreateInput) => {
       },
     },
   });
+
+  return user;
+};
+
+export const createOrGetOauthUser = async (data: OauthUserCreateInput) => {
+  let user = await getUser({
+    oauth: {
+      id: data.id,
+    },
+  });
+
+  if (!user) {
+    user = await prismaClient.user.create({
+      data: {
+        username: data.username,
+        pfp: data.pfp,
+        oauth: {
+          create: {
+            provider: data.provider,
+            id: data.id,
+            access_token: data.accessToken,
+            refresh_token: data.refreshToken,
+          },
+        },
+      },
+    });
+  }
 
   return user;
 };

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import prismaClient from '../database';
 
 export const createUser = async (body: Prisma.UserCreateInput) => {
   return;
@@ -12,6 +13,10 @@ export const deleteUser = async (body: Prisma.UserSelect) => {
   return;
 };
 
-export const getUser = async (body: Prisma.UserSelect) => {
-  return;
+export const getUser = async (body: Prisma.UserWhereInput) => {
+  const user = await prismaClient.user.findFirst({
+    where: body,
+  });
+
+  return user;
 };

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -24,8 +24,10 @@ interface OauthUserCreateInput extends UserCreateInput {
 
 export const createLocalUser = async (data: LocalUserCreateInput) => {
   const userAlreadyExist = await getUser({
-    local: {
-      email: data.email,
+    where: {
+      local: {
+        email: data.email,
+      },
     },
   });
 
@@ -59,8 +61,10 @@ export const createLocalUser = async (data: LocalUserCreateInput) => {
 
 export const createOrGetOauthUser = async (data: OauthUserCreateInput) => {
   let user = await getUser({
-    oauth: {
-      id: data.id,
+    where: {
+      oauth: {
+        id: data.id,
+      },
     },
   });
 
@@ -92,9 +96,9 @@ export const deleteUser = async (data: Prisma.UserSelect) => {
   return;
 };
 
-export const getUser = async (data: Prisma.UserWhereInput) => {
+export const getUser = async (data: Prisma.UserFindFirstArgs) => {
   const user = await prismaClient.user.findFirst({
-    where: data,
+    where: data.where,
   });
 
   return user;


### PR DESCRIPTION
service logic을 controller에서 분리했습니다.

이유는 다음과 같습니다.

1. 가독성이 떨어짐
2. authentication을 마치고 jwt를 발급하는 과정이 local signin 방식과 oauth 를 사용한 방식 중복되어 service logic으로 분리해야했음. ( 이 pull request에는 jwt 발급 방식을 분리하진 않았습니다. )
3. 향후 unit test 환경에서 mocking을 원활하게 할 수 있도록 