### PR TITLE
remove sequelize configuration file

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,5 +1,0 @@
-const path = require('path');
-
-module.exports = {
-  'config': path.resolve('dist/database/config', 'config.js'),
-};


### PR DESCRIPTION
cfe36ecd23d68b48b3544e142e11317fb4822e1c 이후로 sequelize orm이 prisma orm으로 대체되었는데 sequlize configuration이 project root에 여전히 존재해서 제거했습니다.